### PR TITLE
Update PHPUnit and PHP constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 before_script:
   - composer validate --no-check-all --strict
-  - composer update --ignore-platform-reqs $PREFER_LOWEST
+  - composer update $PREFER_LOWEST
 
 script:
   - php testsuite.php --ci

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
         }
     ],
     "require": {
-        "php": "7.0.*|7.1.*|7.2.*",
+        "php": "^7.0,<7.3 || 7.3.0-dev",
         "mso/idna-convert": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0"
+        "phpunit/phpunit": "^6.0 || ^7.0"
     },
     "suggest": {
         "lib-openssl": "*"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "mso/idna-convert": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0|^7.0"
     },
     "suggest": {
         "lib-openssl": "*"


### PR DESCRIPTION
Allow testing on PHP nightly build (php-7.3.0-dev) and PHPUnit 6.* or 7.*