### PR TITLE
Add support for .app domains

### DIFF
--- a/src/whois.app.php
+++ b/src/whois.app.php
@@ -31,11 +31,8 @@ class app_handler {
 
     function parse($data_str, $query) {
         $r = array();
-        $r['regrinfo'] = generic_parser_b($data_str['rawdata'], array(), 'mdy');
-//        $r['regyinfo'] = array(
-//            'referrer' => 'http://www.neulevel.biz',
-//            'registrar' => 'NEULEVEL'
-//        );
+        $r['regrinfo'] = generic_parser_b($data_str['rawdata']);
+        $r['rawdata'] = $data_str['rawdata'];
         return $r;
     }
 

--- a/src/whois.app.php
+++ b/src/whois.app.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2
+ * @license
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * @link http://phpwhois.pw
+ * @copyright Copyright (C)1999,2005 easyDNS Technologies Inc. & Mark Jeftovic
+ * @copyright Maintained by David Saez
+ * @copyright Copyright (c) 2014 Dmitry Lukashin
+ */
+
+if (!defined('__APP_HANDLER__'))
+    define('__APP_HANDLER__', 1);
+
+require_once('whois.parser.php');
+
+class app_handler {
+
+    function parse($data_str, $query) {
+        $r = array();
+        $r['regrinfo'] = generic_parser_b($data_str['rawdata'], array(), 'mdy');
+//        $r['regyinfo'] = array(
+//            'referrer' => 'http://www.neulevel.biz',
+//            'registrar' => 'NEULEVEL'
+//        );
+        return $r;
+    }
+
+}

--- a/src/whois.app.php
+++ b/src/whois.app.php
@@ -23,11 +23,17 @@
  */
 
 if (!defined('__APP_HANDLER__'))
+{
     define('__APP_HANDLER__', 1);
+}
 
 require_once('whois.parser.php');
 
-class app_handler {
+/**
+ * Class app_handler
+ */
+class app_handler
+{
 
     function parse($data_str, $query) {
         $r = array();

--- a/src/whois.servers.php
+++ b/src/whois.servers.php
@@ -84,6 +84,7 @@ return array(
     'airforce'               => 'whois.unitedtld.com',
     'al'                     => '',
     'am'                     => 'whois.amnic.net',
+    'app'                    => 'whois.nic.google',
     'archi'                  => 'whois.ksregistry.net',
     'army'                   => 'whois.rightside.co',
     'arpa'                   => 'whois.iana.org',

--- a/tests/Handlers/AppHandlerTest.php
+++ b/tests/Handlers/AppHandlerTest.php
@@ -22,12 +22,12 @@
 namespace phpWhois\Handlers;
 
 /**
- * OrgHandlerTest
+ * AppHandlerTest
  */
 class AppHandlerTest extends HandlerTest
 {
     /**
-     * @var \org_handler $handler
+     * @var \app_handler $handler
      */
     protected $handler;
 
@@ -38,7 +38,7 @@ class AppHandlerTest extends HandlerTest
     {
         parent::setUp();
 
-        $this->handler            = new \org_handler();
+        $this->handler            = new \app_handler();
         $this->handler->deepWhois = false;
     }
 

--- a/tests/Handlers/AppHandlerTest.php
+++ b/tests/Handlers/AppHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @license   http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2
+ * @license
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * @copyright Copyright (c) 2018 Joshua Smith
+ */
+
+namespace phpWhois\Handlers;
+
+/**
+ * OrgHandlerTest
+ */
+class AppHandlerTest extends HandlerTest
+{
+    /**
+     * @var \org_handler $handler
+     */
+    protected $handler;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->handler            = new \org_handler();
+        $this->handler->deepWhois = false;
+    }
+
+    /**
+     * @return void
+     *
+     * @test
+     */
+    public function parseGoogleDotApp()
+    {
+        $query = 'google.app';
+
+        $fixture = $this->loadFixture($query);
+        $data    = [
+            'rawdata'  => $fixture,
+            'regyinfo' => [],
+        ];
+
+        $actual = $this->handler->parse($data, $query);
+
+        $expected = [
+            'domain'     => [
+                'name'    => 'google.app',
+                'changed' => '2018-09-04',
+                'created' => '2018-03-29',
+                'expires' => '2019-03-29',
+            ],
+            'registered' => 'yes',
+        ];
+
+        $this->assertArraySubset($expected, $actual['regrinfo'], 'Whois data may have changed');
+        $this->assertArrayHasKey('rawdata', $actual);
+        $this->assertArraySubset($fixture, $actual['rawdata'], 'Fixture data may be out of date');
+    }
+}

--- a/tests/fixtures/google.app.txt
+++ b/tests/fixtures/google.app.txt
@@ -1,0 +1,113 @@
+% IANA WHOIS server
+% for more information on IANA, visit http://www.iana.org
+% This query returned 1 object
+
+refer:        whois.nic.google
+
+domain:       APP
+
+organisation: Charleston Road Registry Inc.
+address:      1600 Amphitheatre Parkway Mountain View, CA 94043
+address:      United States
+
+contact:      administrative
+name:         Domains Policy and Compliance
+organisation: Google Inc.
+address:      601 N. 34th Street
+address:      Seattle, WA 98103
+address:      United States
+phone:        1 202 642 2325
+fax-no:       1 650 492 5631
+e-mail:       iana-contact@google.com
+
+contact:      technical
+name:         Richard Roberto
+organisation: Google Inc
+address:      76 9th Avenue, 4th Floor
+address:      New York, NY 10011
+address:      United States
+phone:        1 212 565 2633
+fax-no:       1 650 492 5631
+e-mail:       crr-tech@google.com
+
+nserver:      NS-TLD1.CHARLESTONROADREGISTRY.COM 2001:4860:4802:32:0:0:0:69 216.239.32.105
+nserver:      NS-TLD2.CHARLESTONROADREGISTRY.COM 2001:4860:4802:34:0:0:0:69 216.239.34.105
+nserver:      NS-TLD3.CHARLESTONROADREGISTRY.COM 2001:4860:4802:36:0:0:0:69 216.239.36.105
+nserver:      NS-TLD4.CHARLESTONROADREGISTRY.COM 2001:4860:4802:38:0:0:0:69 216.239.38.105
+nserver:      NS-TLD5.CHARLESTONROADREGISTRY.COM 2001:4860:4805:0:0:0:0:69 216.239.60.105
+ds-rdata:     23684 8 2 3a5cc8a31e02c94aba6461912fabb7e9f5e34957bb6114a55a864d96aec31836
+
+whois:        whois.nic.google
+
+status:       ACTIVE
+remarks:      Registration information: http://www.registry.google
+
+created:      2015-06-25
+changed:      2018-06-09
+source:       IANA
+
+Domain Name: google.app
+Registry Domain ID: 2C5A4BAFF-APP
+Registrar WHOIS Server: whois.nic.google
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2018-04-09T14:29:14Z
+Creation Date: 2018-03-29T16:02:13Z
+Registry Expiry Date: 2019-03-29T16:02:13Z
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registry Registrant ID: REDACTED FOR PRIVACY
+Registrant Name: REDACTED FOR PRIVACY
+Registrant Organization: Google LLC
+Registrant Street: REDACTED FOR PRIVACY
+Registrant City: REDACTED FOR PRIVACY
+Registrant State/Province: CA
+Registrant Postal Code: REDACTED FOR PRIVACY
+Registrant Country: US
+Registrant Phone: REDACTED FOR PRIVACY
+Registrant Fax: REDACTED FOR PRIVACY
+Registrant Email: REDACTED FOR PRIVACY
+Registry Admin ID: REDACTED FOR PRIVACY
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Fax: REDACTED FOR PRIVACY
+Admin Email: REDACTED FOR PRIVACY
+Registry Tech ID: REDACTED FOR PRIVACY
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Fax: REDACTED FOR PRIVACY
+Tech Email: REDACTED FOR PRIVACY
+Registry Billing ID: REDACTED FOR PRIVACY
+Billing Name: REDACTED FOR PRIVACY
+Billing Organization: REDACTED FOR PRIVACY
+Billing Street: REDACTED FOR PRIVACY
+Billing City: REDACTED FOR PRIVACY
+Billing State/Province: REDACTED FOR PRIVACY
+Billing Postal Code: REDACTED FOR PRIVACY
+Billing Country: REDACTED FOR PRIVACY
+Billing Phone: REDACTED FOR PRIVACY
+Billing Fax: REDACTED FOR PRIVACY
+Billing Email: REDACTED FOR PRIVACY
+Name Server: ns1.googledomains.com
+Name Server: ns2.googledomains.com
+Name Server: ns3.googledomains.com
+Name Server: ns4.googledomains.com
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2018-07-20T20:25:45Z <<<


### PR DESCRIPTION
Using `generic_parser_b` to add support for Google's `.app` domains.