### PR TITLE
Throw an exception when trying an unsupported TLD, instead of returni…

### DIFF
--- a/src/Whois.php
+++ b/src/Whois.php
@@ -250,13 +250,7 @@ class Whois extends WhoisClient
      */
     public function unknown()
     {
-        unset($this->query['server']);
-        $this->query['status'] = 'error';
-        $result = array('rawdata' => array());
-        $result['rawdata'][] = $this->query['errstr'][] = $this->query['query'] . ' domain is not supported';
-        $this->checkDns($result);
-        $this->fixResult($result, $this->query['query']);
-        return $result;
+        throw new \InvalidArgumentException($this->query['query'] . ' domain is not supported');
     }
 
     /**


### PR DESCRIPTION
…ng empty data.