### PR TITLE
Check array key, which is not always existing (in de_handler)

### DIFF
--- a/src/whois.de.php
+++ b/src/whois.de.php
@@ -68,8 +68,10 @@ class de_handler
         if (!isset($r['regrinfo']['domain']['status']) || $r['regrinfo']['domain']['status'] === 'free') {
             $r['regrinfo']['registered'] = 'no';
         } else {
-            $r['regrinfo']['domain']['changed'] = substr($r['regrinfo']['domain']['changed'], 0, 10);
-            $r['regrinfo']['registered']        = 'yes';
+            if (isset($r['regrinfo']['domain']['changed'])) {
+                $r['regrinfo']['domain']['changed'] = substr($r['regrinfo']['domain']['changed'], 0, 10);
+            }
+            $r['regrinfo']['registered'] = 'yes';
         }
 
         return $r;


### PR DESCRIPTION
If a domain is in status 'connect' the array key `changed` is not set in `$r['regrinfo']['domain']`. This triggers the notice `Undefined index: changed` in line 71 of file `src/whois.de.php`.

To fix this issue I have added a check via `isset`.