### PR TITLE
Improve parsing of dates in standard format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 5.6.0 - 2020-05-11
 ------------------
-* Officially support PHP 7.4
+* Officially support PHP 7.4 (TorbenLundsgaard, jsmitty12)
 * Replace abandoned `mso/idna-convert` dependency
 * Fix _Undefined index_ notice in `.de` handler (naitsirch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+5.6.1 - 2020-05-30
+------------------
+* Improve date parsing when a standard format is used (jsmitty12)
+
 5.6.0 - 2020-05-11
 ------------------
 * Officially support PHP 7.4 (TorbenLundsgaard, jsmitty12)

--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -741,6 +741,11 @@ function format_dates(&$res, $format = 'mdy') {
 
 function get_date($date, $format)
 {
+    $parsedDate = parseStandardDate($date);
+    if ($parsedDate instanceof DateTime) {
+        return $parsedDate->format('Y-m-d');
+    }
+
     $months = [
         'jan' => 1,
         'ene' => 1,
@@ -841,4 +846,28 @@ function get_date($date, $format)
         $res['y'] += 1900;
 
     return sprintf('%.4d-%02d-%02d', $res['y'], $res['m'], $res['d']);
+}
+
+/**
+ * @param string $date
+ *
+ * @return false|DateTime
+ */
+function parseStandardDate(string $date) {
+    $date = trim($date);
+
+    $pattern = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/';
+    if (preg_match($pattern, $date)) {
+        $dateTimeFormat = 'Y-m-d\TH:i:sT';
+        return Datetime::createFromFormat($dateTimeFormat, $date);
+    }
+
+    $pattern = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/';
+    if (preg_match($pattern, $date)) {
+        $dateTimeFormat = 'Y-m-d\TH:i:s';
+        $utc = new DateTimeZone('UTC');
+        return Datetime::createFromFormat($dateTimeFormat, $date, $utc);
+    }
+
+    return false;
 }

--- a/tests/Handlers/AppHandlerTest.php
+++ b/tests/Handlers/AppHandlerTest.php
@@ -62,7 +62,7 @@ class AppHandlerTest extends HandlerTest
         $expected = [
             'domain'     => [
                 'name'    => 'google.app',
-                'changed' => '2018-09-04',
+                'changed' => '2018-04-09',
                 'created' => '2018-03-29',
                 'expires' => '2019-03-29',
             ],

--- a/tests/Handlers/OrgHandlerTest.php
+++ b/tests/Handlers/OrgHandlerTest.php
@@ -73,4 +73,37 @@ class OrgHandlerTest extends HandlerTest
         $this->assertArrayHasKey('rawdata', $actual);
         $this->assertArraySubset($fixture, $actual['rawdata'], 'Fixture data may be out of date');
     }
+
+    /**
+     * @return void
+     *
+     * @test
+     */
+    public function parseDatesProperly()
+    {
+        $query = 'scottishrecoveryconsortium.org';
+
+        $fixture = $this->loadFixture($query);
+        $data    = [
+            'rawdata'  => $fixture,
+            'regyinfo' => [],
+        ];
+
+        $actual = $this->handler->parse($data, $query);
+
+        $expected = [
+            'domain'     => [
+                'name'    => 'SCOTTISHRECOVERYCONSORTIUM.ORG',
+            ],
+            'registered' => 'yes',
+        ];
+
+        $this->assertArraySubset($expected, $actual['regrinfo'], 'Whois data may have changed');
+        $this->assertArrayHasKey('rawdata', $actual);
+        $this->assertArraySubset($fixture, $actual['rawdata'], 'Fixture data may be out of date');
+
+        $this->assertEquals('2020-01-13', $actual['regrinfo']['domain']['changed'], 'Incorrect change date');
+        $this->assertEquals('2012-10-01', $actual['regrinfo']['domain']['created'], 'Incorrect created date');
+        $this->assertEquals('2020-10-01', $actual['regrinfo']['domain']['expires'], 'Incorrect expiration date');
+    }
 }

--- a/tests/fixtures/scottishrecoveryconsortium.org.txt
+++ b/tests/fixtures/scottishrecoveryconsortium.org.txt
@@ -1,0 +1,234 @@
+Connecting to ORG.whois-servers.net...
+
+WHOIS Server: whois.tucows.com
+Registrar URL: http://www.tucows.com
+Updated Date: 2020-01-13T11:22:25Z
+Creation Date: 2012-10-01T15:32:42Z
+Registry Expiry Date: 2020-10-01T15:32:42Z
+Registrar Registration Expiration Date:
+Registrar: Tucows Inc.
+Registrar IANA ID: 69
+Registrar Abuse Contact Email: domainabuse@tucows.com
+Registrar Abuse Contact Phone: +1.4165350123
+Reseller:
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registrant Organization: Scottish Recovery Consortium
+Registrant State/Province: Glasgow
+Registrant Country: GB
+Name Server: NS1.STACKDNS.COM
+Name Server: NS2.STACKDNS.COM
+Name Server: NS3.STACKDNS.COM
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form https://www.icann.org/wicf/)
+>>> Last update of WHOIS database: 2020-05-29T22:11:59Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Access to Public Interest Registry WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Public Interest Registry registry database. The data in this record is provided by Public Interest Registry for informational purposes only, and Public Interest Registry does not guarantee its accuracy. This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to (a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Public Interest Registry reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
+
+The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+
+Connecting to whois.tucows.com...
+
+WHOIS Server: whois.tucows.com
+Registrar URL: http://tucowsdomains.com
+Updated Date: 2020-01-13T11:22:22
+Creation Date: 2012-10-01T15:32:42
+Registrar Registration Expiration Date: 2020-10-01T15:32:42
+Registrar: TUCOWS, INC.
+Registrar IANA ID: 69
+Reseller: Fasthosts Internet Limited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registry Registrant ID: 
+Registrant Name: REDACTED FOR PRIVACY
+Registrant Organization: REDACTED FOR PRIVACY
+Registrant Street: REDACTED FOR PRIVACY 
+Registrant City: REDACTED FOR PRIVACY
+Registrant State/Province: Glasgow
+Registrant Postal Code: REDACTED FOR PRIVACY
+Registrant Country: GB
+Registrant Phone: REDACTED FOR PRIVACY
+Registrant Phone Ext: 
+Registrant Fax: REDACTED FOR PRIVACY
+Registrant Fax Ext: 
+Registrant Email: https://tieredaccess.com/contact/2fc25366-18de-445d-ad3e-36338247fa37
+Registry Admin ID: 
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY 
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Phone Ext: 
+Admin Fax: REDACTED FOR PRIVACY
+Admin Fax Ext: 
+Admin Email: REDACTED FOR PRIVACY
+Registry Tech ID: 
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY 
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Phone Ext: 
+Tech Fax: REDACTED FOR PRIVACY
+Tech Fax Ext: 
+Tech Email: REDACTED FOR PRIVACY
+Name Server: ns1.stackdns.com
+Name Server: ns2.stackdns.com
+Name Server: ns3.stackdns.com
+DNSSEC: unsigned
+Registrar Abuse Contact Email: domainabuse@tucows.com
+Registrar Abuse Contact Phone: +1.4165350123
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+>>> Last update of WHOIS database: 2020-05-29T22:12:59Z <<<
+
+"For more information on Whois status codes, please visit https://icann.org/epp"
+
+Registration Service Provider:
+    Fasthosts Internet Limited, domains@fasthosts.co.uk
+    +44.3330142700
+    http://www.Fasthosts.co.uk
+    http://facebook.com/fasthostsinternet
+
+The Data in the Tucows Registrar WHOIS database is provided to you by Tucows
+for information purposes only, and may be used to assist you in obtaining
+information about or related to a domain name's registration record.
+
+Tucows makes this information available "as is," and does not guarantee its
+accuracy.
+
+By submitting a WHOIS query, you agree that you will use this data only for
+lawful purposes and that, under no circumstances will you use this data to:
+a) allow, enable, or otherwise support the transmission by e-mail,
+telephone, or facsimile of mass, unsolicited, commercial advertising or
+solicitations to entities other than the data recipient's own existing
+customers; or (b) enable high volume, automated, electronic processes that
+send queries or data to the systems of any Registry Operator or
+ICANN-Accredited registrar, except as reasonably necessary to register
+domain names or modify existing registrations.
+
+The compilation, repackaging, dissemination or other use of this Data is
+expressly prohibited without the prior written consent of Tucows.
+
+Tucows reserves the right to terminate your access to the Tucows WHOIS
+database in its sole discretion, including without limitation, for excessive
+querying of the WHOIS database or for failure to otherwise abide by this
+policy.
+
+Tucows reserves the right to modify these terms at any time.
+
+By submitting this query, you agree to abide by these terms.
+
+NOTE: THE WHOIS DATABASE IS A CONTACT DATABASE ONLY.  LACK OF A DOMAIN
+RECORD DOES NOT SIGNIFY DOMAIN AVAILABILITY.
+
+
+
+Domain Name: SCOTTISHRECOVERYCONSORTIUM.ORG
+Registry Domain ID: D166733159-LROR
+Registrar WHOIS Server: whois.tucows.com
+Registrar URL: http://tucowsdomains.com
+Updated Date: 2020-01-13T11:22:22
+Creation Date: 2012-10-01T15:32:42
+Registrar Registration Expiration Date: 2020-10-01T15:32:42
+Registrar: TUCOWS, INC.
+Registrar IANA ID: 69
+Reseller: Fasthosts Internet Limited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registry Registrant ID: 
+Registrant Name: REDACTED FOR PRIVACY
+Registrant Organization: REDACTED FOR PRIVACY
+Registrant Street: REDACTED FOR PRIVACY 
+Registrant City: REDACTED FOR PRIVACY
+Registrant State/Province: Glasgow
+Registrant Postal Code: REDACTED FOR PRIVACY
+Registrant Country: GB
+Registrant Phone: REDACTED FOR PRIVACY
+Registrant Phone Ext: 
+Registrant Fax: REDACTED FOR PRIVACY
+Registrant Fax Ext: 
+Registrant Email: https://tieredaccess.com/contact/2fc25366-18de-445d-ad3e-36338247fa37
+Registry Admin ID: 
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY 
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Phone Ext: 
+Admin Fax: REDACTED FOR PRIVACY
+Admin Fax Ext: 
+Admin Email: REDACTED FOR PRIVACY
+Registry Tech ID: 
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY 
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Phone Ext: 
+Tech Fax: REDACTED FOR PRIVACY
+Tech Fax Ext: 
+Tech Email: REDACTED FOR PRIVACY
+Name Server: ns1.stackdns.com
+Name Server: ns2.stackdns.com
+Name Server: ns3.stackdns.com
+DNSSEC: unsigned
+Registrar Abuse Contact Email: domainabuse@tucows.com
+Registrar Abuse Contact Phone: +1.4165350123
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+>>> Last update of WHOIS database: 2020-05-29T22:12:59Z <<<
+
+"For more information on Whois status codes, please visit https://icann.org/epp"
+
+Registration Service Provider:
+    Fasthosts Internet Limited, domains@fasthosts.co.uk
+    +44.3330142700
+    http://www.Fasthosts.co.uk
+    http://facebook.com/fasthostsinternet
+
+The Data in the Tucows Registrar WHOIS database is provided to you by Tucows
+for information purposes only, and may be used to assist you in obtaining
+information about or related to a domain name's registration record.
+
+Tucows makes this information available "as is," and does not guarantee its
+accuracy.
+
+By submitting a WHOIS query, you agree that you will use this data only for
+lawful purposes and that, under no circumstances will you use this data to:
+a) allow, enable, or otherwise support the transmission by e-mail,
+telephone, or facsimile of mass, unsolicited, commercial advertising or
+solicitations to entities other than the data recipient's own existing
+customers; or (b) enable high volume, automated, electronic processes that
+send queries or data to the systems of any Registry Operator or
+ICANN-Accredited registrar, except as reasonably necessary to register
+domain names or modify existing registrations.
+
+The compilation, repackaging, dissemination or other use of this Data is
+expressly prohibited without the prior written consent of Tucows.
+
+Tucows reserves the right to terminate your access to the Tucows WHOIS
+database in its sole discretion, including without limitation, for excessive
+querying of the WHOIS database or for failure to otherwise abide by this
+policy.
+
+Tucows reserves the right to modify these terms at any time.
+
+By submitting this query, you agree to abide by these terms.
+
+NOTE: THE WHOIS DATABASE IS A CONTACT DATABASE ONLY.  LACK OF A DOMAIN
+RECORD DOES NOT SIGNIFY DOMAIN AVAILABILITY.
+
+


### PR DESCRIPTION
Correctly parse dates specified in the format: `yyyy-mm-ddThh:mm:ssZ`

Fixes #49 