### PR TITLE
Fixed the fixture loading function for unit tests

### DIFF
--- a/tests/Handlers/HandlerTest.php
+++ b/tests/Handlers/HandlerTest.php
@@ -42,7 +42,8 @@ abstract class HandlerTest extends TestCase
             $which
         );
         if (file_exists($fixture)) {
-            return file($fixture);
+            $raw = file_get_contents($fixture);
+            return explode("\n", $raw);
         }
 
         throw new \InvalidArgumentException('Cannot find fixture');


### PR DESCRIPTION
The `loadFixture` function of the abstract HandlerTest used PHP's `file` function to load the fixture files. The problem is that 'Each line in the resulting array will include the line ending, unless FILE_IGNORE_NEW_LINES is used'[1]. An empty line in the fixture file will be represented by an array item consisting of "\n" instead of "".

But this differs from the real WhoisClient where `explode("\n", $raw)` is used to convert the raw result from the whois server to the array that will be parsed. This way empty lines will be represented by an empty string "" in the array.

At the end the parser uses other data in tests compared to real life.