### PR TITLE
Updated the unit test fixture for google.de.txt

### DIFF
--- a/tests/fixtures/google.de.txt
+++ b/tests/fixtures/google.de.txt
@@ -1,38 +1,19 @@
-% Copyright (c) 2010 by DENIC
-% Version: 2.0
-% 
 % Restricted rights.
-% 
+%
 % Terms and Conditions of Use
-% 
-% The data in this record is provided by DENIC for informational purposes only.
-% DENIC does not guarantee its accuracy and cannot, under any circumstances,
-% be held liable in case the stored information would prove to be wrong,
-% incomplete or not accurate in any sense.
-% 
-% All the domain data that is visible in the whois service is protected by law.
-% It is not permitted to use it for any purpose other than technical or
-% administrative requirements associated with the operation of the Internet.
-% It is explicitly forbidden to extract, copy and/or use or re-utilise in any
-% form and by any means (electronically or not) the whole or a quantitatively
-% or qualitatively substantial part of the contents of the whois database
-% without prior and explicit written permission by DENIC.
-% It is prohibited, in particular, to use it for transmission of unsolicited
-% and/or commercial and/or advertising by phone, fax, e-mail or for any similar
-% purposes.
-% 
-% By maintaining the connection you assure that you have a legitimate interest
-% in the data and that you will only use it for the stated purposes. You are
-% aware that DENIC maintains the right to initiate legal proceedings against
-% you in the event of any breach of this assurance and to bar you from using
-% its whois service.
-% 
-% The DENIC whois service on port 43 never discloses any information concerning
-% the domain holder/administrative contact. Information concerning the domain
-% holder/administrative contact can be obtained through use of our web-based
-% whois service available at the DENIC website:
+%
+% The above data may only be used within the scope of technical or
+% administrative necessities of Internet operation or to remedy legal
+% problems.
+% The use for other purposes, in particular for advertising, is not permitted.
+%
+% The DENIC whois service on port 43 doesn't disclose any information concerning
+% the domain holder, general request and abuse contact.
+% This information can be obtained through use of our web-based whois service
+% available at the DENIC website:
 % http://www.denic.de/en/domains/whois-service/web-whois.html
-% 
+%
+%
 
 Domain: google.de
 Nserver: ns1.google.com
@@ -40,31 +21,4 @@ Nserver: ns2.google.com
 Nserver: ns3.google.com
 Nserver: ns4.google.com
 Status: connect
-Changed: 2011-03-30T19:36:27+02:00
-
-[Tech-C]
-Type: PERSON
-Name: DNS Admin
-Organisation: Google Inc.
-Address: 1600 Amphitheatre Parkway
-PostalCode: 94043
-City: Mountain View
-CountryCode: US
-Phone: +1.6502530000
-Fax: +1.6506188571
-Email: email@google.com
-Changed: 2011-03-11T00:04:49+01:00
-
-[Zone-C]
-Type: PERSON
-Name: Domain Admin
-Organisation: MarkMonitor Inc
-Address: 3540 East Longwing Lane
-Address: Suite 300
-PostalCode: 83646
-City: Meridian
-CountryCode: US
-Phone: +1.2083895740
-Fax: +1.2083895771
-Email: email@markmonitor.com
-Changed: 2017-06-05T17:55:26+02:00
+Changed: 2018-03-12T21:44:25+01:00


### PR DESCRIPTION
Result from whois.denic.de at June 2nd, 2020.

After the changes in the european law (the GDPR) the DENIC has changed the output of their whois service.