### PR TITLE
Remove replace from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,4 @@
     "config": {
         "sort-packages": true
     },
-    "replace": {
-        "phpwhois/phpwhois": "4.2.*"
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -58,5 +58,5 @@
     },
     "config": {
         "sort-packages": true
-    },
+    }
 }


### PR DESCRIPTION
The old phpwhois package is no longer equivalent as it contains security vulnerabilities that are now fixed in this fork.

This package will currently fail roave/security-advisories checks when requiring due to this.