### PR TITLE
Fix .kiwi whois server address

### DIFF
--- a/src/whois.servers.php
+++ b/src/whois.servers.php
@@ -318,7 +318,7 @@ return array(
     'ki'                     => 'whois.nic.ki',
     'kim'                    => 'whois.afilias.net',
     'kitchen'                => 'whois.donuts.co',
-    'kiwi'                   => 'whois.dot-kiwi.com',
+    'kiwi'                   => 'whois.nic.kiwi',
     'koeln'                  => 'whois-fe1.pdt.koeln.tango.knipp.de',
     'kr'                     => 'whois.kr',
     'krd'                    => 'whois.aridnrs.net.au',


### PR DESCRIPTION
The current address incorrect and does not respond. The updated one however does work.

Mentions of this address on https://hello.kiwi/whois