### PR TITLE
Support PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ jobs:
     - php: nightly
   include:
     - php: 8.0
-      env: IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
     - php: nightly
-      env: IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
 
 env:
   jobs:
@@ -34,7 +32,7 @@ install:
 before_script:
   - php -i
   - composer validate --no-check-all --strict
-  - composer update $PREFER_LOWEST $IGNORE_PLATFORM_REQS
+  - composer update $PREFER_LOWEST
 
 script:
 #  - php testsuite.php --ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# https://config.travis-ci.com/explore
 os: linux
 dist: xenial
 
@@ -7,14 +8,17 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - nightly
 
 jobs:
   fast_finish: true
   allow_failures:
-    - php:
-        nightly
+    - php: 8.0
+    - php: nightly
   include:
+    - php: 8.0
+      env: IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
     - php: nightly
       env: IGNORE_PLATFORM_REQS="--ignore-platform-reqs"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
 
 env:
   jobs:
-    - PREFER_LOWEST="--prefer-lowest --prefer-stable"
+#    - PREFER_LOWEST="--prefer-lowest --prefer-stable"
     - PREFER_LOWEST=""
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+6.0.0 - 2020-12-05
+----------------------
+* Work around deprecated PHPUnit method
+* Use `algo26-matthias/idna-convert@dev-master` while waiting for official PHP 8.0 support
+* Simplify CI testing
+
 6.0.0-rc1 - 2020-10-04
 ----------------------
 * Enable support for PHPUnit 8 & 9

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "algo26-matthias/idna-convert": "^3.0"
+        "algo26-matthias/idna-convert": "^3.0 || dev-master"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "~0.1",

--- a/tests/WhoisClientTest.php
+++ b/tests/WhoisClientTest.php
@@ -7,7 +7,13 @@ class WhoisClientTest extends \PHPUnit\Framework\TestCase
     public function testVersion()
     {
         $client = new WhoisClient();
-        $this->assertRegExp('/^(\d+)\.(\d+)\.(\d+)(-\w+)*$/', $client->codeVersion);
+
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/^(\d+)\.(\d+)\.(\d+)(-\w+)*$/', $client->codeVersion);
+        } else {
+            // Deprecated in PHPUnit 9
+            $this->assertRegExp('/^(\d+)\.(\d+)\.(\d+)(-\w+)*$/', $client->codeVersion);
+        }
     }
 
     /**

--- a/tests/WhoisClientTest.php
+++ b/tests/WhoisClientTest.php
@@ -6,7 +6,7 @@ class WhoisClientTest extends \PHPUnit\Framework\TestCase
 {
     public function testVersion()
     {
-        $client = new WhoisClient;
+        $client = new WhoisClient();
         $this->assertRegExp('/^(\d+)\.(\d+)\.(\d+)(-\w+)*$/', $client->codeVersion);
     }
 
@@ -15,35 +15,35 @@ class WhoisClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testParseServer($server, $result)
     {
-        $whoisClient = new WhoisClient;
+        $whoisClient = new WhoisClient();
         $this->assertEquals($result, $whoisClient->parseServer($server));
     }
 
     public function serversProvider()
     {
-        return array(
-            array('http://www.phpwhois.pw:80/', array('scheme' => 'http', 'host' => 'www.phpwhois.pw', 'port' => 80)),
-            array('http://www.phpwhois.pw:80', array('scheme' => 'http', 'host' => 'www.phpwhois.pw', 'port' => 80)),
-            array('http://www.phpwhois.pw', array('scheme' => 'http', 'host' => 'www.phpwhois.pw')),
-            array('www.phpwhois.pw:80', array('host' => 'www.phpwhois.pw', 'port' => 80)),
-            array('www.phpwhois.pw:80/', array('host' => 'www.phpwhois.pw', 'port' => 80)),
-            array('www.phpwhois.pw', array('host' => 'www.phpwhois.pw')),
-            array('www.phpwhois.pw/', array('host' => 'www.phpwhois.pw')),
-            array('http://127.0.0.1:80/', array('scheme' => 'http', 'host' => '127.0.0.1', 'port' => 80)),
-            array('http://127.0.0.1:80', array('scheme' => 'http', 'host' => '127.0.0.1', 'port' => 80)),
-            array('http://127.0.0.1', array('scheme' => 'http', 'host' => '127.0.0.1')),
-            array('127.0.0.1:80', array('host' => '127.0.0.1', 'port' => 80)),
-            array('127.0.0.1:80/', array('host' => '127.0.0.1', 'port' => 80)),
-            array('127.0.0.1', array('host' => '127.0.0.1')),
-            array('127.0.0.1/', array('host' => '127.0.0.1')),
-            array('http://[1a80:1f45::ebb:12]:80/', array('scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]', 'port' => 80)),
-            array('http://[1a80:1f45::ebb:12]:80', array('scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]', 'port' => 80)),
-            array('http://[1a80:1f45::ebb:12]', array('scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]')),
-            //array('http://1a80:1f45::ebb:12', array('scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]')),
-            array('[1a80:1f45::ebb:12]:80', array('host' => '[1a80:1f45::ebb:12]', 'port' => 80)),
-            array('[1a80:1f45::ebb:12]:80/', array('host' => '[1a80:1f45::ebb:12]', 'port' => 80)),
-            array('1a80:1f45::ebb:12', array('host' => '[1a80:1f45::ebb:12]')),
-            array('1a80:1f45::ebb:12/', array('host' => '[1a80:1f45::ebb:12]')),
-        );
+        return [
+            ['http://www.phpwhois.pw:80/', ['scheme' => 'http', 'host' => 'www.phpwhois.pw', 'port' => 80]],
+            ['http://www.phpwhois.pw:80', ['scheme' => 'http', 'host' => 'www.phpwhois.pw', 'port' => 80]],
+            ['http://www.phpwhois.pw', ['scheme' => 'http', 'host' => 'www.phpwhois.pw']],
+            ['www.phpwhois.pw:80', ['host' => 'www.phpwhois.pw', 'port' => 80]],
+            ['www.phpwhois.pw:80/', ['host' => 'www.phpwhois.pw', 'port' => 80]],
+            ['www.phpwhois.pw', ['host' => 'www.phpwhois.pw']],
+            ['www.phpwhois.pw/', ['host' => 'www.phpwhois.pw']],
+            ['http://127.0.0.1:80/', ['scheme' => 'http', 'host' => '127.0.0.1', 'port' => 80]],
+            ['http://127.0.0.1:80', ['scheme' => 'http', 'host' => '127.0.0.1', 'port' => 80]],
+            ['http://127.0.0.1', ['scheme' => 'http', 'host' => '127.0.0.1']],
+            ['127.0.0.1:80', ['host' => '127.0.0.1', 'port' => 80]],
+            ['127.0.0.1:80/', ['host' => '127.0.0.1', 'port' => 80]],
+            ['127.0.0.1', ['host' => '127.0.0.1']],
+            ['127.0.0.1/', ['host' => '127.0.0.1']],
+            ['http://[1a80:1f45::ebb:12]:80/', ['scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]', 'port' => 80]],
+            ['http://[1a80:1f45::ebb:12]:80', ['scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]', 'port' => 80]],
+            ['http://[1a80:1f45::ebb:12]', ['scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]']],
+            // ['http://1a80:1f45::ebb:12', ['scheme' => 'http', 'host' => '[1a80:1f45::ebb:12]']],
+            ['[1a80:1f45::ebb:12]:80', ['host' => '[1a80:1f45::ebb:12]', 'port' => 80]],
+            ['[1a80:1f45::ebb:12]:80/', ['host' => '[1a80:1f45::ebb:12]', 'port' => 80]],
+            ['1a80:1f45::ebb:12', ['host' => '[1a80:1f45::ebb:12]']],
+            ['1a80:1f45::ebb:12/', ['host' => '[1a80:1f45::ebb:12]']],
+        ];
     }
 }


### PR DESCRIPTION
- Officially test against PHP 8.0
- Clean up WhoisClientTest (style)
- Work around deprecated PHPUnit method
- Temporarily allow `algo26-matthias/idna-convert` to use dev-master (waiting for official PHP 8.0 support)
- Stop testing with Composer's --prefer-lowest (fails with Xdebug 3.0)

Fixes #79 