### PR TITLE
Stop using `algo26-matthias/idna-convert@dev-master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ php:
 jobs:
   fast_finish: true
   allow_failures:
-    - php: 8.0
-    - php: nightly
-  include:
-    - php: 8.0
     - php: nightly
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.0.1 - 2020-12-10
+----------------------
+* Revert using `algo26-matthias/idna-convert@dev-master`
+
 6.0.0 - 2020-12-05
 ----------------------
 * Work around deprecated PHPUnit method

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "algo26-matthias/idna-convert": "^3.0 || dev-master"
+        "algo26-matthias/idna-convert": "^3.0"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "~0.1",


### PR DESCRIPTION
- @dev-master was intended to be used only until algo26-matthias/idna-convert released a version that supports PHP 8.0, which 3.0.5 does