### PR TITLE
Fix for warning in PHP 8.1

### DIFF
--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -81,7 +81,7 @@ function generic_parser_a_blocks($rawdata, $translate, &$disclaimer)
     $newblock = false;
     $hasdata = false;
     $block = array();
-    $blocks = false;
+    $blocks = array();
     $gkey = 'main';
     $dend = false;
 


### PR DESCRIPTION
> Automatic conversion of false to array is deprecated